### PR TITLE
replace ethereal credentials with valid ones

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -1,5 +1,5 @@
 export default{ 
     JWT_SECRET : "cZNBhV5EMOeJjqp4y3Of3JGVb0+DfMfUK6SeAiLmqwI=",
-    EMAIL: "gracie79@ethereal.email",
-    PASSWORD: "P5adXq1UFrNBKUUfWd"
+    EMAIL: 'wilma.hegmann@ethereal.email',
+    PASSWORD: 'crDRbe7ExnWRDKFSvQ'
 }


### PR DESCRIPTION
## Summary

The point of failure of the signup flow was `ethereal` where the credentials weren't being accepted while trying to send an email using `nodemailer` in the `/registerMail` endpoint. 

The fix was just a replacement of the credentials and the flow works as intended now.

## Related Issue
<!--
Provide information about the issue or bug that is being addressed.
-->

Closes: #[21]


## Description of Changes
<!-- 
Clearly and concisely describe the modifications made to successfully resolve the assigned issue. Include any pertinent information about new files or any other relevant details.

For example:
- Added a new function to handle XYZ.
- Updated the ABC module to fix the bug.
- Refactored code in the DEF class for improved performance.
-->

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] My changes have not introduced any new warnings.
