### PR TITLE
fix: No Padding on contact form

### DIFF
--- a/client/src/components/Contact/Contact.module.css
+++ b/client/src/components/Contact/Contact.module.css
@@ -29,6 +29,7 @@
 	position: relative;
 	background: #19212e;
 	z-index: 10;
+	padding: 30px;
 }
 
 .circle {


### PR DESCRIPTION
## Related Issue
There was no padding on contact form at https://grabbits.vercel.app/contact 
issue : #71

Closes: #71


## Description of Changes
Added padding to .contact_form class in [contact.module.css](https://github.com/GrabBits/GrabBits_Website/blob/main/client/src/components/Contact/Contact.module.css) file

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [ ] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [ ] I have included comments in areas that may be difficult to understand.
- [ ] I have made corresponding updates to the project documentation.
- [ ] My changes have not introduced any new warnings.


## Screenshots

|      Original       |       Updated        |
| :-----------------: | :------------------: |
| ![image](https://github.com/GrabBits/GrabBits_Website/assets/29349136/d55edc70-38c2-43b5-9acf-651701accd5d) | !![image](https://github.com/GrabBits/GrabBits_Website/assets/29349136/79030027-7dbc-4e48-ad02-f53ddde0af41) |


Please provide any necessary screenshots to illustrate the changes made.
