### PR TITLE
#89-cards in center

### DIFF
--- a/client/src/components/Team/Team.module.css
+++ b/client/src/components/Team/Team.module.css
@@ -160,6 +160,7 @@
 }
 
 .name {
+	text-align: center;
 	font-family: 'Poppins', sans-serif;
 	font-style: normal;
 	font-weight: 600;
@@ -312,6 +313,9 @@
 		margin: 0px;
 	}
 	.team_members {
+		display:flex;
+		flex-direction:column;
+		justify-content:center;
 		gap: 0;
 		max-width: 90%;
 		width: 100vw;
@@ -346,6 +350,7 @@
 		padding-left: 4%;
 	}
 	.name {
+		text-align: center;
 		font-size: 14px;
 		margin: 0;
 	}


### PR DESCRIPTION
## Related Issue
#89 
Cards of team member should be in center

Closes: #89 


## Description of Changes
Added a flex property to it
[scrnli_28_05_2023_11-25-08.webm](https://github.com/GrabBits/GrabBits_Website/assets/92094765/85ecfe03-d9ec-4490-bba4-b64007f5e861)

