### PR TITLE
💡 [FEAT]: ACCESSIBILITY IMPROVEMENTS FOR SOCIAL ANCHORS ON FOOTER

### DIFF
--- a/client/src/components/Footer/Footer.jsx
+++ b/client/src/components/Footer/Footer.jsx
@@ -31,12 +31,21 @@ const Footer = () => {
 								<a
 									href="https://www.linkedin.com/company/grabbits/"
 									target="blank"
+									aria-label="Visit us on Linkedin"
+									title="Linkedin (External Link)"
+									rel="noopener noreferrer"
 								>
 									<img className={classes.li_link} src={linkedin}></img>
 								</a>
 							</li>
 							<li className={classes.socia_link}>
-								<a href="https://www.instagram.com/grabbits_/" target="blank">
+								<a 
+									href="https://www.instagram.com/grabbits_/" 
+									target="blank"
+									aria-label="Visit us on Instagram"
+									title="Instagram (External Link)"
+									rel="noopener noreferrer"
+								>
 									<img className={classes.ig_link} src={instagram}></img>
 								</a>
 							</li>
@@ -44,17 +53,32 @@ const Footer = () => {
 								<a
 									href="https://chat.whatsapp.com/KBxP1M7GT7mCh4PORsfN0H"
 									target="blank"
+									aria-label="Join us on WhatsApp"
+									title="WhatsApp (External Link)"
+									rel="noopener noreferrer"
 								>
 									<img className={classes.wp_link} src={whatsapp}></img>
 								</a>
 							</li>
 							<li className={classes.socia_link}>
-								<a href="https://twitter.com/grabbits_" target="blank">
+								<a 
+									href="https://twitter.com/grabbits_" 
+									target="blank"
+									aria-label="Visit us on Twitter"
+									title="Twitter (External Link)"
+									rel="noopener noreferrer"
+								>
 									<img className={classes.twi_link} src={twitter}></img>
 								</a>
 							</li>
 							<li className={classes.socia_link}>
-								<a href="https://www.youtube.com/channel/UCFnVnet_WPnN7VzkGORvzhg?sub_confirmation=1" target="blank">
+								<a 
+									href="https://www.youtube.com/channel/UCFnVnet_WPnN7VzkGORvzhg?sub_confirmation=1" 
+									target="blank"
+								 	aria-label="Visit us on Youtube"
+									title="Youtube (External Link)"
+									rel="noopener noreferrer"
+								>
 									<img className={classes.yt_link} src={youtube}></img>
 								</a>
 							</li>


### PR DESCRIPTION
## Related Issue
- Fixes/Closes: #130 

## Changes proposed
- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Added `title` attribute, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Checklist:

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people
