### PR TITLE
adding scroll-to-top feature in landing page

### DIFF
--- a/client/src/components/Landing/Landing.jsx
+++ b/client/src/components/Landing/Landing.jsx
@@ -4,8 +4,14 @@ import cursor from '../../assets/cursor.png';
 import twocircles from '../../assets/twocircles.svg';
 import card from '../../assets/card.svg';
 import classes from './Landing.module.css';
+import { useEffect } from 'react'; 
 
 const Landing = () => {
+
+	// use scroll and useEffect when route it
+	useEffect(() => {
+		window.scrollTo(0, 0);
+	 }, []);
 	return (
 		<>
 			<div className={classes.landing}>


### PR DESCRIPTION
## Related Issue
When the user clicks on the logo symbol present in the footer while routing to landing page it's position remain same.
<!--
Provide information about the issue or bug that is being addressed.
-->

Closes: #[issue number]
#153 


## Description of Changes
Just uses useEffect and scrollTo() function;
<!-- 
Clearly and concisely describe the modifications made to successfully resolve the assigned issue. Include any pertinent information about new files or any other relevant details.

For example:
- Added a new function to handle XYZ.
- Updated the ABC module to fix the bug.
- Refactored code in the DEF class for improved performance.
-->

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->


- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.


## Screenshots/video

https://github.com/GrabBits/GrabBits_Website/assets/97789487/9f654a49-262d-40b9-8553-06626f9bec7e



