### PR TITLE
Corrected transition of inputs label

### DIFF
--- a/client/src/components/common/Input/Input.module.css
+++ b/client/src/components/common/Input/Input.module.css
@@ -29,7 +29,8 @@
 }
 
 .input:focus ~ label,
-.input:valid ~ label {
+.input:valid ~ label,
+.input:not([value=""]) ~ label {
 	transform: translateY(-50%) scale(0.8);
 	background-color: #212121;
 	padding: 0 0.2em;

--- a/client/src/components/common/Textarea/Textarea.module.css
+++ b/client/src/components/common/Textarea/Textarea.module.css
@@ -23,13 +23,14 @@
 }
 
 .textarea:focus,
-textarea:valid {
+.textarea:valid {
 	outline: none;
 	border: 1.5px solid #1a73e8;
 }
 
 .textarea:focus ~ label,
-teaxtarea:valid ~ label {
+.textarea:valid ~ label,
+.teaxtarea:not([value=""]) ~ label {
 	transform: translateY(-50%) scale(0.8);
 	background-color: #212121;
 	padding: 0 0.2em;


### PR DESCRIPTION
## Related Issue
The transition of the label of Inputs in Contact and Home page 

Closes: #237 


## Description of Changes

- Earlier the transition was happening only when there was valid text inside, because of which it was not keeping transition in case of email and query inputs.
- Now the inputs boxes keep the transition of the label when there is text inside.

## Checklist:

<!--
Mark the checkboxes to indicate completion. Example: 
- [x] My code follows the style guidelines of this project.
-->

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots

|      Original       |       Updated        |
| :-----------------: | :------------------: |
| 
![image](https://github.com/GrabBits/GrabBits_Website/assets/100359818/b306d3ec-4c6f-4475-9f2b-a1176d8d29ae)
| 
![image](https://github.com/GrabBits/GrabBits_Website/assets/100359818/435dd6a9-f035-4453-9cba-aec704f1e8bd)
 |


Please provide any necessary screenshots to illustrate the changes made.
