### PR TITLE
Current Podcast Cards Made even

### DIFF
--- a/client/src/components/common/PodcastCard/PodcastCard.jsx
+++ b/client/src/components/common/PodcastCard/PodcastCard.jsx
@@ -8,24 +8,28 @@ const PodcastCard = ({ podcast = {}, show, imgPreview }) => {
 	return (
 		<>
 			<div className={classes.podcast_card}>
-				{show ? (
-					<img
-						className={classes.podcast_image}
-						src={imgPreview}
-						alt="youtube_header"
-					/>
-				) : (
-					<img
-						className={classes.podcast_image}
-						src={`data:image/png;base64, ${image}`}
-						alt="youtube_header"
-					/>
-				)}
-				<h3 className={classes.podcast_name}>{title}</h3>
-				<h4 className={classes.podcast_person}>{name}</h4>
-				<div className={classes.separator}></div>
-				<div className={classes.btn_container}>
-					<Button link={link} label="Watch Video" bgColor="#7541C8" />
+				<div className={classes.w100}>
+					{show ? (
+						<img
+							className={classes.podcast_image}
+							src={imgPreview}
+							alt="youtube_header"
+						/>
+					) : (
+						<img
+							className={classes.podcast_image}
+							src={`data:image/png;base64, ${image}`}
+							alt="youtube_header"
+						/>
+					)}
+					<h3 className={classes.podcast_name}>{title}</h3>
+					<h4 className={classes.podcast_person}>{name}</h4>
+				</div>
+				<div className={classes.w100}>
+					<div className={classes.separator}></div>
+					<div className={classes.btn_container}>
+						<Button link={link} label="Watch Video" bgColor="#7541C8" />
+					</div>
 				</div>
 			</div>
 		</>

--- a/client/src/components/common/PodcastCard/PodcastCard.module.css
+++ b/client/src/components/common/PodcastCard/PodcastCard.module.css
@@ -1,23 +1,34 @@
 .podcast_card {
 	display: flex;
-	justify-content: center;
+	justify-content: space-between;
 	align-items: flex-start;
 	flex-direction: column;
-	gap: 10px;
 	background-color: #19212e;
 	width: 300px;
-	height: auto;
+	overflow: hidden;
+	height: 370px;
 	border-radius: 12px 12px 12px 12px;
 	margin: 10px;
-	padding: 0 0 20px 0;
 	box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px,
 		rgba(0, 0, 0, 0.3) 0px 30px 60px -30px,
 		rgba(10, 37, 64, 0.35) 0px -2px 6px 0px inset;
 }
+
+.w100{
+	gap: 5px;
+
+	width: 100%;
+	display: flex;
+	flex-direction: column;
+	padding-bottom: 14px;
+}
+
 .podcast_image {
 	width: 300px;
-	border-radius: 12px 12px 0 0;
+	height: 170px;
+	border-radius: 12px 12px 0 0;
 }
+
 .podcast_card:hover .podcast_image {
 	animation: wobble 1s ease-in-out 1;
 }


### PR DESCRIPTION
## Related Issue
The podcast cards are made even, regardless of the content in it.

Closes: #[issue number]
#245 

## Description of Changes
- Updated PodcastCard.module.css
- Updated PodcastCard.jsx

## Checklist:

- [x] My code adheres to the established style guidelines of this project.
- [x] I have conducted a self-review of my code.
- [x] I have included comments in areas that may be difficult to understand.
- [x] I have made corresponding updates to the project documentation.
- [x] My changes have not introduced any new warnings.


## Screenshots

|      Original       |       Updated        |
| :-----------------: | :------------------: |
| ![Screenshot 2023-07-01 232644](https://github.com/GrabBits/GrabBits_Website/assets/98682478/18ceb433-97ae-4a19-a5b3-c7608b347e50) | ![image](https://github.com/GrabBits/GrabBits_Website/assets/98682478/eb5d9166-6505-4703-97a0-245230bba89f)|

![image](https://github.com/GrabBits/GrabBits_Website/assets/98682478/940cebc6-1f1a-490d-97dd-1635550c542e)


